### PR TITLE
UIEH-645: Extend plugin so it can receive custom button as a trigger for modal

### DIFF
--- a/AgreementSearch/AgreementSearch.js
+++ b/AgreementSearch/AgreementSearch.js
@@ -3,14 +3,10 @@ import PropTypes from 'prop-types';
 import { Button, Icon } from '@folio/stripes/components';
 import AgreementSearchModal from './AgreementSearchModal';
 
+const triggerId = 'find-agreement-trigger';
 class AgreementSearch extends React.Component {
   static propTypes = {
-    searchButtonLabel: PropTypes.node,
-    searchButtonStyle: PropTypes.string,
-  };
-
-  static defaultProps = {
-    searchButtonStyle: 'primary noRightRadius',
+    renderTrigger: PropTypes.func,
   };
 
   state = {
@@ -25,18 +21,35 @@ class AgreementSearch extends React.Component {
     this.setState({ open: false });
   }
 
+  renderDefaultTrigger() {
+    return (
+      <Button
+        id={triggerId}
+        buttonStyle="primary noRightRadius"
+        onClick={this.openModal}
+      >
+        <Icon icon="search" color="#fff" />
+      </Button>
+    );
+  }
+
+  renderTriggerButton() {
+    const {
+      renderTrigger,
+    } = this.props;
+
+    return renderTrigger
+      ? renderTrigger({
+        id: triggerId,
+        onClick: this.openModal,
+      })
+      : this.renderDefaultTrigger();
+  }
+
   render() {
     return (
       <React.Fragment>
-        <Button
-          id="clickable-find-agreement"
-          buttonStyle={this.props.searchButtonStyle}
-          onClick={this.openModal}
-        >
-          <Icon icon="search" color="#fff">
-            {this.props.searchButtonLabel}
-          </Icon>
-        </Button>
+        {this.renderTriggerButton()}
         <AgreementSearchModal
           open={this.state.open}
           onClose={this.closeModal}


### PR DESCRIPTION
## Purpose
The plugin renders its own button for triggering modal with agreements. This button contains a hardcoded icon. But there is a need to pass a custom button to the plugin.

## Approach
Extend plugin with `renderTrigger` prop. Plugin renders passed trigger or default when `renderTrigger` is not present.

[Jira ticket](https://issues.folio.org/browse/UIEH-645)