### PR TITLE
Set syncToLocationSearch to false

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -85,6 +85,10 @@ export default class Container extends React.Component {
     if (this.searchField.current) {
       this.searchField.current.focus();
     }
+
+    this.props.mutator.agreementSearchParams.update({
+      filters: 'agreementStatus.Active,agreementStatus.Draft,agreementStatus.In negotiation,agreementStatus.Requested',
+    });
   }
 
   handleNeedMoreData = () => {

--- a/src/View.js
+++ b/src/View.js
@@ -193,6 +193,7 @@ export default class Agreements extends React.Component {
           initialSearchState={{ query: '' }}
           queryGetter={queryGetter}
           querySetter={querySetter}
+          syncToLocationSearch={false}
         >
           {
             ({


### PR DESCRIPTION
Should've been setting this to `false` always, the only reason it worked without error is that `ui-eholdings` (the only current user of this plugin) doesn't use the same query params as this plugin does.