### PR TITLE
ERM-477: Updated strings for agreement periods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed clear button in search box.
 * Added support for agreement periods.
 * Added support for erm interface 2.0
+* Added permission set
 
 ## 3.0.1 2019-04-06
 * Added translations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-plugin-find-agreement
 
+## 3.1.0 IN PROGRESS
+* Fixed clear button in search box.
+* Added support for agreement periods.
+* Added support for erm interface 2.0
+
 ## 3.0.1 2019-04-06
 * Added translations
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-find-agreement",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "ERM-agreement-finder for Stripes",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
@@ -34,6 +34,9 @@
   "stripes": {
     "type": "plugin",
     "pluginType": "find-agreement",
-    "displayName": "ui-plugin-find-agreement.meta.title"
+    "displayName": "ui-plugin-find-agreement.meta.title",
+    "okapiInterfaces": {
+      "erm": "1.0 2.0"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^16.6.3"
   },
   "dependencies": {
-    "@folio/stripes-erm-components": "^1.4.0",
+    "@folio/stripes-erm-components": "^1.4.0||^2.0.0",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.0",
     "react-intl": "^2.4.0"
@@ -37,6 +37,17 @@
     "displayName": "ui-plugin-find-agreement.meta.title",
     "okapiInterfaces": {
       "erm": "1.0 2.0"
-    }
+    },
+    "permissionSets": [
+      {
+        "permissionName": "ui-plugin-find-agreement.search",
+        "displayName": "Find Agreement Plugin: Search agreements",
+        "visible": true,
+        "subPermissions": [
+          "erm.agreements.view",
+          "erm.orgs.view"
+        ]
+      }
+    ]
   }
 }

--- a/src/Container.js
+++ b/src/Container.js
@@ -31,22 +31,22 @@ export default class Container extends React.Component {
     },
     agreementStatusValues: {
       type: 'okapi',
-      path: 'erm/refdataValues/SubscriptionAgreement/agreementStatus',
+      path: 'erm/refdata/SubscriptionAgreement/agreementStatus',
       shouldRefresh: () => false,
     },
     renewalPriorityValues: {
       type: 'okapi',
-      path: 'erm/refdataValues/SubscriptionAgreement/renewalPriority',
+      path: 'erm/refdata/SubscriptionAgreement/renewalPriority',
       shouldRefresh: () => false,
     },
     isPerpetualValues: {
       type: 'okapi',
-      path: 'erm/refdataValues/SubscriptionAgreement/isPerpetual',
+      path: 'erm/refdata/SubscriptionAgreement/isPerpetual',
       shouldRefresh: () => false,
     },
     orgRoleValues: {
       type: 'okapi',
-      path: 'erm/refdataValues/SubscriptionAgreementOrg/role',
+      path: 'erm/refdata/SubscriptionAgreementOrg/role',
       shouldRefresh: () => false,
     },
     tagsValues: {

--- a/src/View.js
+++ b/src/View.js
@@ -68,8 +68,8 @@ export default class Agreements extends React.Component {
   columnMapping = {
     name: <FormattedMessage id="ui-plugin-find-agreement.prop.name" />,
     agreementStatus: <FormattedMessage id="ui-plugin-find-agreement.prop.agreementStatus" />,
-    startDate: <FormattedMessage id="ui-plugin-find-agreement.prop.startDate" />,
-    endDate: <FormattedMessage id="ui-plugin-find-agreement.prop.endDate" />,
+    startDate: <FormattedMessage id="ui-plugin-find-agreement.prop.periodStart" />,
+    endDate: <FormattedMessage id="ui-plugin-find-agreement.prop.periodEnd" />,
     cancellationDeadline: <FormattedMessage id="ui-plugin-find-agreement.prop.cancellationDeadline" />,
   }
 
@@ -232,11 +232,7 @@ export default class Agreements extends React.Component {
                                 marginBottom0
                                 name="query"
                                 onChange={getSearchHandlers().query}
-                                onClear={() => {
-                                  getSearchHandlers().clear();
-                                  // TODO: Add way to trigger search automatically
-                                  // onSubmitSearch();
-                                }}
+                                onClear={getSearchHandlers().reset}
                                 value={searchValue.query}
                               />
                             )}

--- a/translations/ui-plugin-find-agreement/en.json
+++ b/translations/ui-plugin-find-agreement/en.json
@@ -8,13 +8,13 @@
 
   "prop.agreementStatus": "Status",
   "prop.cancellationDeadline": "Cancellation deadline",
-  "prop.endDate": "End date",
   "prop.isPerpetual": "Is perpetual",
   "prop.name": "Name",
   "prop.organizations": "Organizations",
   "prop.orgRole": "Organization role",
+  "prop.periodEnd": "Period start",
+  "prop.periodStart": "Period start",
   "prop.renewalPriority": "Renewal priority",
-  "prop.startDate": "Start date",
   "prop.tags": "Tags"
 
 }


### PR DESCRIPTION
- Since start/end dates for the current period are in the same place, we only need to change the column headers to "support" agreement periods.
- Registered the fact that we use the `erm` okapi interface. Technically this is backwards-compatible with v1.0.
- Looped in a fix I found for the clearing of the text search field.
