### PR TITLE
Add and document a new optional `openByDefault` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 7.0.0 (In Progress)
 * Included interface dependency for erm 5.0
+* Add and document optional `openByDefault` property.
 
 ## 6.1.0 2021-06-16
 * ERM-1597 Add descriptions to visible permission set in ui-plugin-find-agreement

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ of the Module Developer's Guide.
 | `onAgreementSelected` | func: (agreement) => {} | Callback fired when a user clicks a agreement | Yes |
 | `dataKey` | string | Optional `dataKey` passed to stripes/connect when creating the connected Agreements component. |  |
 | `renderTrigger` | func: ({ triggerId, onClick, buttonRef }) => {} | Optional render function for the button to open the License search modal. The `onClick` prop should be called when the trigger is clicked (assuming it is a Button). The `buttonRef` ensures that the trigger button is brought back into focus once the lookup modal is closed| |
+| `openByDefault` | boolean | Optionally specifies that the plugin should appear in its opened state when intitially rendered, as opposed to rendering only the trigger [default: `false`] |
 
 ## Additional information
 

--- a/src/AgreementSearch.js
+++ b/src/AgreementSearch.js
@@ -9,6 +9,7 @@ const triggerId = 'find-agreement-trigger';
 export default class AgreementSearch extends React.Component {
   static propTypes = {
     renderTrigger: PropTypes.func,
+    openByDefault: PropTypes.bool,
   };
 
   constructor(props) {

--- a/src/AgreementSearch.js
+++ b/src/AgreementSearch.js
@@ -17,7 +17,7 @@ export default class AgreementSearch extends React.Component {
     this.modalRef = React.createRef();
     this.modalTrigger = React.createRef();
     this.state = {
-      open: false,
+      open: props.openByDefault || false,
     };
   }
 


### PR DESCRIPTION
Optionally specifies that the plugin should appear in its opened state
when intitially rendered, as opposed to rendering only the trigger
[default: `false`]

We need this because of the way the plugin is rendered outside the
context of a trigger in `ui-plugin-eusage-reports`.