### PR TITLE
chore: Bumped to stripes-kint-components ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "typescript": "^2.8.0"
   },
   "dependencies": {
-    "@k-int/stripes-kint-components": "^3.0.3",
+    "@k-int/stripes-kint-components": "^4.0.0",
     "dom-helpers": "^3.4.0",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.0"

--- a/src/Container.js
+++ b/src/Container.js
@@ -82,7 +82,7 @@ const Container = ({ onSelectRow }) => {
     ['ERM', 'Agreements', agreementsQueryParams, AGREEMENTS_ENDPOINT],
     ({ pageParam = 0 }) => {
       const params = [...agreementsQueryParams, `offset=${pageParam}`];
-      return ky.get(encodeURI(`${AGREEMENTS_ENDPOINT}?${params?.join('&')}`)).json();
+      return ky.get(`${AGREEMENTS_ENDPOINT}?${params?.join('&')}`).json();
     }
   );
 


### PR DESCRIPTION
kint-components 4.0.0 introduces a breaking change, encodeURI should no longer be performed on the output of generateKiwtQueryParams unless `encode` is set to false