### PR TITLE
chore: Stripes-erm-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@folio/eslint-config-stripes": "^6.3.0",
     "@folio/stripes": "^7.3.1",
     "@folio/stripes-cli": "^2.6.1",
-    "@folio/stripes-erm-components": "^7.0.1",
+    "@folio/stripes-erm-components": "^8.0.0",
     "@folio/stripes-erm-testing": "^1.0.0",
     "@folio/stripes-testing": "^4.2.0",
     "@formatjs/cli": "^4.2.31",
@@ -86,7 +86,7 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^7.3.1",
-    "@folio/stripes-erm-components": "^7.0.1",
+    "@folio/stripes-erm-components": "^8.0.0",
     "react": "^17.0.2",
     "react-intl": "^5.8.1",
     "react-router-dom": "^5.2.0"


### PR DESCRIPTION
Bumped major version of stripes-erm-components to ^8.0.0, reflecting removal of testing stuff for Orchid

ERM-2457