### PR TITLE
ERM-2908: Default filters displayed but not applied on opening ui-plugin-find-agreement

### DIFF
--- a/src/View/View.js
+++ b/src/View/View.js
@@ -161,6 +161,7 @@ const Agreements = ({
         initialSortState={{ sort: 'name' }}
         queryGetter={queryGetter}
         querySetter={querySetter}
+        setQueryOnMount
         syncToLocationSearch={false}
       >
         {


### PR DESCRIPTION
fix: setQueryOnMount

Ensure initial query conditions are met for first mount, meaning that initial filter state etc makes it to the first fetch made for agreements with the plugin

ERM-2908